### PR TITLE
fix(scripts/tag-automation): handle updation on title-only page 

### DIFF
--- a/src/libs/scrapbox/private-api/websocket-clinet/internal/commit-change-param.ts
+++ b/src/libs/scrapbox/private-api/websocket-clinet/internal/commit-change-param.ts
@@ -8,25 +8,31 @@ import {
   createUpdationChange,
 } from './commit-change';
 
-type InsertParam = { type: 'insert'; id: ID; position?: ID; text: string };
+type InsertParam = { type: 'insert'; position?: ID; text: string };
 type UpdateParam = { type: 'update'; id: ID; text: string };
 type DeleteParam = { type: 'delete'; id: ID };
 type TitleParam = { type: 'title'; title: string };
 type DescriptionParam = { type: 'description'; text: string };
 export type CommitChangeParam = InsertParam | UpdateParam | DeleteParam | TitleParam | DescriptionParam;
 
-const createChange = (param: CommitChangeParam): CommitChange => {
-  if (param.type === 'insert') {
-    return createInsertionChange(param);
-  } else if (param.type === 'update') {
-    return createUpdationChange(param);
-  } else if (param.type === 'delete') {
-    return createDeletionChange(param);
-  } else if (param.type === 'title') {
-    return createTitleChange(param);
+/**
+ * @param source
+ * @param userId - to generate new ID of user
+ */
+const createChange = (source: CommitChangeParam, userId: ID): CommitChange => {
+  if (source.type === 'insert') {
+    return createInsertionChange(source, userId);
+  } else if (source.type === 'update') {
+    return createUpdationChange(source);
+  } else if (source.type === 'delete') {
+    return createDeletionChange(source);
+  } else if (source.type === 'title') {
+    return createTitleChange(source);
+  } else if (source.type === 'description') {
+    return createDescriptionChange(source);
   } else {
-    return createDescriptionChange(param);
+    throw new Error('Bad implement');
   }
 };
 
-export const createChanges = (params: CommitChangeParam[]): CommitChange[] => params.map(createChange);
+export const createChanges = (params: CommitChangeParam[], userId: ID): CommitChange[] => params.map((p) => createChange(p, userId));

--- a/src/libs/scrapbox/private-api/websocket-clinet/internal/commit-change.ts
+++ b/src/libs/scrapbox/private-api/websocket-clinet/internal/commit-change.ts
@@ -1,4 +1,4 @@
-import { ID } from '../../../public-api';
+import { generateId, ID } from '../../../public-api';
 
 export type InsertCommitChange = {
   // point to insert, all after here go down one line.
@@ -29,11 +29,11 @@ export type DescriptionsCommitChange = { descriptions: string[] };
 
 export type CommitChange = InsertCommitChange | UpdateCommitChange | DeleteCommitChange | TitleCommitChange | DescriptionsCommitChange;
 
-export const createInsertionChange = (param: { id: ID; position?: ID; text: string }): InsertCommitChange => {
+export const createInsertionChange = (param: { text: string; position?: ID }, userId: ID): InsertCommitChange => {
   return {
     _insert: param.position || '_end',
     lines: {
-      id: param.id,
+      id: generateId(userId),
       text: param.text,
     },
   };

--- a/src/libs/scrapbox/private-api/websocket-clinet/websocket-client.ts
+++ b/src/libs/scrapbox/private-api/websocket-clinet/websocket-client.ts
@@ -51,7 +51,7 @@ export class WebsocketClient {
         projectId: param.projectId,
         pageId: param.pageId,
         parentId: param.parentId,
-        changes: createChanges(param.changes),
+        changes: createChanges(param.changes, param.userId),
         cursor: null,
         freeze: true,
       },

--- a/src/scripts/tag-template-automation/internal/create-line-insertions.spec.ts
+++ b/src/scripts/tag-template-automation/internal/create-line-insertions.spec.ts
@@ -13,12 +13,37 @@ describe('createLineInsertions', () => {
   const has3LinesEOF = [{ text: 'Symbol' }, { text: '#tag' }, { text: '' }] as any;
 
   it('should work', () => {
-    expect(createLineInsertions(words, date, dailyTitleOnly)).toEqual([{ text: '#12:00 #tag1 #tag2' }, { text: '' }]);
-    expect(createLineInsertions(words, date, dailyTitleEOF)).toEqual([{ text: '#12:00 #tag1 #tag2' }, { text: '' }]);
-    expect(createLineInsertions(words, date, symbolTitleOnly)).toEqual([{ text: '#2020/02/09 #tag1 #tag2' }, { text: '' }]);
-    expect(createLineInsertions(words, date, symbolTitleEOF)).toEqual([{ text: '#2020/02/09 #tag1 #tag2' }, { text: '' }]);
-    expect(createLineInsertions(words, date, hasPreviousTags)).toEqual([{ text: '' }, { text: '#2020/02/09 #tag1 #tag2' }, { text: '' }]);
-    expect(createLineInsertions(words, date, has3Lines)).toEqual([{ text: '' }, { text: '#2020/02/09 #tag1 #tag2' }, { text: '' }]);
-    expect(createLineInsertions(words, date, has3LinesEOF)).toEqual([{ text: '#2020/02/09 #tag1 #tag2' }, { text: '' }]);
+    expect(createLineInsertions(words, date, dailyTitleOnly)).toEqual([
+      { type: 'insert', text: '#12:00 #tag1 #tag2' },
+      { type: 'insert', text: '' },
+      { type: 'description', text: 'tagLineText' },
+    ]);
+    expect(createLineInsertions(words, date, dailyTitleEOF)).toEqual([
+      { type: 'insert', text: '#12:00 #tag1 #tag2' },
+      { type: 'insert', text: '' },
+    ]);
+    expect(createLineInsertions(words, date, symbolTitleOnly)).toEqual([
+      { type: 'insert', text: '#2020/02/09 #tag1 #tag2' },
+      { type: 'insert', text: '' },
+      { type: 'description', text: 'tagLineText' },
+    ]);
+    expect(createLineInsertions(words, date, symbolTitleEOF)).toEqual([
+      { type: 'insert', text: '#2020/02/09 #tag1 #tag2' },
+      { type: 'insert', text: '' },
+    ]);
+    expect(createLineInsertions(words, date, hasPreviousTags)).toEqual([
+      { type: 'insert', text: '' },
+      { type: 'insert', text: '#2020/02/09 #tag1 #tag2' },
+      { type: 'insert', text: '' },
+    ]);
+    expect(createLineInsertions(words, date, has3Lines)).toEqual([
+      { type: 'insert', text: '' },
+      { type: 'insert', text: '#2020/02/09 #tag1 #tag2' },
+      { type: 'insert', text: '' },
+    ]);
+    expect(createLineInsertions(words, date, has3LinesEOF)).toEqual([
+      { type: 'insert', text: '#2020/02/09 #tag1 #tag2' },
+      { type: 'insert', text: '' },
+    ]);
   });
 });

--- a/src/scripts/tag-template-automation/open-dialog-and-write-tags.ts
+++ b/src/scripts/tag-template-automation/open-dialog-and-write-tags.ts
@@ -15,7 +15,7 @@ export const openDialogAndWriteTags = async () => {
 
         loadPage(title);
       } else {
-        await api.insertLine(createLineInsertions(result.data));
+        await api.changeLine(createLineInsertions(result.data));
       }
     }
   } catch (e) {


### PR DESCRIPTION
websocket message must contain "descriptions" commit change when we try to update contents of only-title page.